### PR TITLE
Fix GitHub Actions workflow failure

### DIFF
--- a/src/app/api/sentry-example-api/route.ts
+++ b/src/app/api/sentry-example-api/route.ts
@@ -1,4 +1,3 @@
-export const dynamic = 'force-dynamic';
 class SentryExampleAPIError extends Error {
   constructor(message: string | undefined) {
     super(message);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,9 +4,6 @@ import { HeroHeader } from '@/components/header';
 import HeroSection from '@/components/hero-section';
 import { HomePageWrapper } from '@/components/home-page-wrapper';
 
-// Static generation with revalidation - improve Core Web Vitals
-export const revalidate = 86400; // Revalidate every 24 hours
-
 // SEO Metadata for better performance and discoverability
 export const metadata: Metadata = {
   title: 'AI SaaS Starter Kit - Build Your AI Application Fast',


### PR DESCRIPTION
Remove `export const dynamic` and `export const revalidate` exports that are incompatible with Next.js 16 cacheComponents feature. The new cacheLife API in next.config.ts handles caching behavior.

- Remove `dynamic = 'force-dynamic'` from sentry-example-api route
- Remove `revalidate = 86400` from page.tsx

Fixes build error: "Route segment config is not compatible with nextConfig.cacheComponents"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted caching configuration for an API route and page template. These changes may affect how content and responses are cached and served.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->