### PR TITLE
fix: disable experimental cacheComponents to fix build errors

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -33,35 +33,8 @@ const nextConfig: NextConfig = {
   experimental: {
     optimizeCss: true,
     optimizePackageImports: ['lucide-react', '@radix-ui/react-icons'],
-    cacheComponents: true,
-
-    // Next.js 16 Cache Components - Explicit caching configuration
-    cacheLife: {
-      // Default cache profile - for user profiles, dashboards
-      default: {
-        stale: 3600, // 1 hour - serve stale content for this duration
-        revalidate: 900, // 15 minutes - revalidate in background
-        expire: 86400, // 1 day - hard expiration
-      },
-      // Short cache - for analytics, frequently changing data
-      short: {
-        stale: 60, // 1 minute
-        revalidate: 30, // 30 seconds
-        expire: 300, // 5 minutes
-      },
-      // Long cache - for blog posts, product catalogs
-      long: {
-        stale: 86400, // 1 day
-        revalidate: 3600, // 1 hour
-        expire: 604800, // 1 week
-      },
-      // Forever cache - for static content, configuration
-      forever: {
-        stale: Number.POSITIVE_INFINITY,
-        revalidate: 604800, // 1 week
-        expire: Number.POSITIVE_INFINITY,
-      },
-    },
+    // cacheComponents disabled due to incompatibility with API routes and system pages
+    // cacheComponents: true,
   },
 
   // Comprehensive security headers

--- a/src/app/api/sentry-example-api/route.ts
+++ b/src/app/api/sentry-example-api/route.ts
@@ -1,3 +1,5 @@
+export const dynamic = 'force-dynamic';
+
 class SentryExampleAPIError extends Error {
   constructor(message: string | undefined) {
     super(message);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,6 +4,9 @@ import { HeroHeader } from '@/components/header';
 import HeroSection from '@/components/hero-section';
 import { HomePageWrapper } from '@/components/home-page-wrapper';
 
+// Static generation with revalidation - improve Core Web Vitals
+export const revalidate = 86400; // Revalidate every 24 hours
+
 // SEO Metadata for better performance and discoverability
 export const metadata: Metadata = {
   title: 'AI SaaS Starter Kit - Build Your AI Application Fast',

--- a/src/lib/subscription-features.ts
+++ b/src/lib/subscription-features.ts
@@ -1,6 +1,5 @@
 import 'server-only';
 import { cache } from 'react';
-import { unstable_cacheLife as cacheLife } from 'next/cache';
 import { eq } from 'drizzle-orm';
 import { db } from '@/db/drizzle';
 import { subscription as subscriptionTable } from '@/db/schema';
@@ -47,13 +46,9 @@ export type PlanFeatures = (typeof PLAN_FEATURES)[PlanName];
 /**
  * Get user's current subscription plan
  * Returns 'free' if no active subscription found
- * Cached with 'default' profile (1 hour stale, 15 min revalidate)
- * Combined with React cache for request deduplication
+ * Cached with React cache for request deduplication
  */
 export const getUserPlan = cache(async (userId: string): Promise<PlanName> => {
-  'use cache';
-  cacheLife('default');
-
   try {
     const subscription = await db.query.subscription.findFirst({
       where: eq(subscriptionTable.userId, userId),
@@ -83,9 +78,6 @@ export const getUserPlan = cache(async (userId: string): Promise<PlanName> => {
  */
 export const getUserPlanFeatures = cache(
   async (userId: string): Promise<PlanFeatures> => {
-    'use cache';
-    cacheLife('default');
-
     const plan = await getUserPlan(userId);
     return PLAN_FEATURES[plan];
   },


### PR DESCRIPTION
Disabled the experimental cacheComponents feature that was causing prerendering errors with API routes and system pages. Reverted to standard Next.js caching approach.

Changes:
- Disable cacheComponents in next.config.ts (still experimental with known issues)
- Restore route segment configs (dynamic, revalidate) now that they're compatible
- Update /api/models to use standard fetch caching (next.revalidate) instead of unstable_cacheLife
- Update subscription-features.ts to remove 'use cache' directives
- Add dynamic = 'force-dynamic' to API routes to prevent prerendering

Fixes build errors:
- "Route /api/models needs to bail out of prerendering"
- "Route /_not-found: Uncached data was accessed outside of <Suspense>"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed experimental caching configurations to improve platform stability and ensure compatibility with API routes and system pages.
  * Migrated caching mechanisms to use standard Next.js revalidation strategies, replacing experimental caching features with stable, production-ready alternatives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->