### PR TITLE
Diagnose failing end-to-end tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@
 # testing
 *.log
 /unit-tests/coverage/
+/test-results/
+/playwright-report/
 
 # next.js
 /.next/

--- a/E2E_TEST_DIAGNOSTIC_REPORT.md
+++ b/E2E_TEST_DIAGNOSTIC_REPORT.md
@@ -1,0 +1,540 @@
+# E2E Testing Diagnostic Report
+
+**Date**: 2025-11-18
+**Status**: All e2e tests failing due to infrastructure issues
+**Total Tests**: 240 (108 unique tests × 5 browser configurations)
+
+---
+
+## Executive Summary
+
+All e2e tests (240 tests across 5 browser configurations) are **failing due to a critical infrastructure issue**: the application server cannot start because required environment variables are missing.
+
+---
+
+## Root Cause Analysis
+
+### Primary Issue: Missing Environment Configuration
+
+**Error Location**: `src/db/drizzle.ts:8:9`
+
+**Error Message**:
+```
+Error: DATABASE_URL environment variable is required
+```
+
+**Impact**: The Playwright webserver cannot start the Next.js application, causing all 240 tests to fail before any actual test execution.
+
+### Additional Configuration Issues
+
+The application requires these critical environment variables (from `.env.example`):
+
+**Required for Application Startup**:
+- `DATABASE_URL` - PostgreSQL connection string ⚠️ **MISSING**
+- `BETTER_AUTH_SECRET` - Authentication secret key
+- `BETTER_AUTH_URL` - Base URL for authentication
+
+**Required for Full Functionality**:
+- `ENCRYPTION_KEY` - For API key encryption
+- `POLAR_ACCESS_TOKEN` - Payment provider integration
+- `RESEND_API_KEY` - Email service
+- `OPENAI_API_KEY` - AI chat functionality
+- `ARCJET_KEY` - Rate limiting
+- Various `POLAR_PRODUCT_*` IDs for subscription tiers
+
+### Secondary Issues
+
+**Dependency Warnings** (non-blocking but should be addressed):
+- Missing packages: `import-in-the-middle`, `require-in-the-middle`, `prettier`
+- These are peer dependencies for OpenTelemetry instrumentation and React Email
+
+---
+
+## Current E2E Test Coverage Analysis
+
+### Test Files Overview
+
+| Test File | Focus Area | Test Count | Status |
+|-----------|------------|------------|--------|
+| `auth.spec.ts` | Authentication flows | ~24 | ❌ Not running |
+| `dashboard.spec.ts` | Dashboard navigation | ~15 | ❌ Not running |
+| `admin.spec.ts` | Admin access control | ~12 | ❌ Not running |
+| `subscription-flow.spec.ts` | Billing/subscriptions | ~9 | ❌ Not running |
+| `theme-readability.spec.ts` | UI accessibility & theming | ~48 | ❌ Not running |
+
+**Total Tests**: 108 unique tests × 5 browser configurations = **240 test executions**
+
+**Browser Coverage**:
+- Desktop Chrome (Chromium)
+- Desktop Firefox
+- Desktop Safari (WebKit)
+- Mobile Chrome (Pixel 5)
+- Mobile Safari (iPhone 12)
+
+### What IS Being Tested
+
+#### 1. Authentication (auth.spec.ts) ✅ Good Coverage
+- Landing page display
+- Navigation to login/signup pages
+- Form validation (empty fields)
+- Invalid credentials handling
+- Password reset flow navigation
+- Form field presence validation
+- Protected route redirects
+
+#### 2. Dashboard (dashboard.spec.ts) ⚠️ Limited
+- Unauthenticated redirect behavior
+- Basic navigation structure checks
+- Conditional rendering based on auth state
+
+#### 3. Admin Panel (admin.spec.ts) ⚠️ Limited
+- Access control for non-admin users
+- Authentication requirements
+- Basic navigation presence
+
+#### 4. Subscriptions (subscription-flow.spec.ts) ⚠️ Limited
+- Plan display (Free, Pro, Startup)
+- Upgrade button presence
+- Usage information display
+
+#### 5. Theme/Accessibility (theme-readability.spec.ts) ✅ Comprehensive
+- Light/dark mode color contrast (WCAG compliance)
+- Input border visibility
+- Button contrast ratios
+- Status color accessibility
+- OKLCH color support
+- Focus indicators
+- High contrast mode support
+
+---
+
+## Critical Gaps in E2E Testing
+
+### 🔴 High Priority Missing Tests
+
+#### 1. **Complete Authentication Flows**
+Currently tested: Form navigation and validation
+
+**Missing**:
+- ❌ Actual user registration (sign up → email verification → login)
+- ❌ Successful login flow with valid credentials
+- ❌ Logout functionality
+- ❌ Password reset complete flow (email → reset → login)
+- ❌ Google OAuth integration
+- ❌ Session persistence across page refreshes
+- ❌ Token expiration and refresh
+
+#### 2. **AI Chat Functionality** - ZERO Coverage
+The application's core feature has no e2e tests:
+- ❌ Chat interface interaction
+- ❌ Message sending and streaming responses
+- ❌ API key management (add/edit/delete)
+- ❌ Different AI model selection
+- ❌ Session persistence
+- ❌ Error handling (API key invalid, quota exceeded)
+
+#### 3. **Workspace/Multi-Tenancy Features** - ZERO Coverage
+Major feature with no testing:
+- ❌ Workspace creation
+- ❌ Workspace member management (invite/remove)
+- ❌ Role-based permissions (owner/admin/member)
+- ❌ Workspace settings modifications
+- ❌ Switching between workspaces
+- ❌ Workspace deletion
+- ❌ Invitation acceptance flow
+
+#### 4. **Payment & Subscription Flows** - Minimal Coverage
+Currently: Only checks if plans are displayed
+
+**Missing**:
+- ❌ Subscription upgrade flow (Free → Pro)
+- ❌ Payment processing (checkout)
+- ❌ Subscription management (cancel/upgrade/downgrade)
+- ❌ Usage quota enforcement
+- ❌ Feature gating by plan
+- ❌ Billing history display
+- ❌ Invoice generation
+
+#### 5. **Admin Dashboard** - Minimal Coverage
+Currently: Only access control checks
+
+**Missing**:
+- ❌ User management (list/view/edit/delete users)
+- ❌ Audit log filtering and viewing
+- ❌ System analytics viewing
+- ❌ User role modifications
+- ❌ Workspace oversight
+
+### 🟡 Medium Priority Missing Tests
+
+#### 6. **API Key Management**
+- ❌ Create/edit/delete user API keys
+- ❌ Encrypted storage verification
+- ❌ API key usage in chat
+
+#### 7. **Analytics Dashboard**
+- ❌ Usage metrics display
+- ❌ Chart rendering
+- ❌ Date range filtering
+- ❌ Export functionality
+
+#### 8. **Session Management**
+- ❌ Session list display
+- ❌ Session details viewing
+- ❌ Session deletion
+
+#### 9. **API Documentation Page**
+- ❌ Swagger UI rendering
+- ❌ API endpoint testing through UI
+
+#### 10. **User Settings**
+- ❌ Profile updates
+- ❌ Email change
+- ❌ Password change
+- ❌ Account deletion
+
+### 🟢 Lower Priority Missing Tests
+
+#### 11. **Error Scenarios**
+- ❌ Network failures
+- ❌ API timeouts
+- ❌ Invalid data handling
+- ❌ 404 pages
+- ❌ Error boundary testing
+
+#### 12. **Performance**
+- ❌ Page load times
+- ❌ Large data set handling (pagination)
+- ❌ Concurrent user actions
+
+#### 13. **Mobile-Specific Features**
+- ❌ Touch gestures
+- ❌ Responsive layout breakpoints
+- ❌ Mobile navigation (hamburger menu)
+
+#### 14. **Email Workflows**
+- ❌ Email verification (requires email testing service)
+- ❌ Invitation emails
+- ❌ Password reset emails
+
+---
+
+## Test Quality Assessment
+
+### Strengths ✅
+1. **Excellent Browser Coverage**: 5 different browser/device combinations
+2. **Accessibility Testing**: Comprehensive WCAG compliance checks
+3. **Good Test Structure**: Well-organized with clear descriptions
+4. **Proper Test Isolation**: Each test file has clear boundaries
+
+### Weaknesses ❌
+1. **No Authenticated User Flows**: Tests mostly check unauthenticated behavior
+2. **Shallow Testing**: Many tests only verify element presence, not functionality
+3. **No Data Mutation Tests**: No tests for create/update/delete operations
+4. **Missing Core Features**: AI chat, workspaces, and payments barely tested
+5. **No Test Fixtures**: No helper to create authenticated test users
+6. **No API Mocking**: Tests depend on actual backend services
+
+---
+
+## Comparison: Unit vs E2E Coverage
+
+### Unit Tests (Vitest): **163+ tests** ✅ Excellent
+- Comprehensive utility function coverage
+- API route testing with mocks
+- Component rendering tests
+- Database operation tests
+- Integration tests for key workflows
+
+### E2E Tests (Playwright): **108 unique tests** ⚠️ Insufficient
+- Only 5 test files covering limited scenarios
+- Missing critical user journeys
+- No happy path completion tests
+- Core features untested
+
+### Coverage Gap
+The unit tests provide good code coverage, but **e2e tests fail to validate complete user journeys** that span multiple pages and API calls.
+
+---
+
+## Recommendations
+
+### Immediate Actions (Fix Current Issues)
+
+#### 1. Create Test Environment Configuration
+```bash
+# Create .env.test file with test database
+cp .env.example .env.test
+# Add test-specific values with a dedicated test database
+```
+
+#### 2. Configure Playwright to Use Test Environment
+Update `playwright.config.ts`:
+```typescript
+webServer: {
+  command: 'cp .env.test .env && pnpm dev',
+  // ... rest of config
+}
+```
+
+Or use environment variable:
+```typescript
+use: {
+  baseURL: process.env.PLAYWRIGHT_TEST_BASE_URL || 'http://localhost:3000',
+}
+```
+
+#### 3. Set Up Test Database
+- Use a separate test database (not production)
+- Run migrations before tests
+- Seed with test data
+- Clean up after tests
+
+#### 4. Install Missing Dependencies (Optional)
+```bash
+pnpm add -D import-in-the-middle require-in-the-middle prettier
+```
+
+### Short-term Improvements (1-2 weeks)
+
+#### 5. Create Test Fixtures (`e2e/fixtures.ts`)
+- Helper to create authenticated users
+- Test workspace creation
+- Subscription state helpers
+
+Example:
+```typescript
+import { test as base } from '@playwright/test';
+
+export const test = base.extend({
+  authenticatedPage: async ({ page }, use) => {
+    // Login logic here
+    await page.goto('/login');
+    await page.fill('[name="email"]', 'test@example.com');
+    await page.fill('[name="password"]', 'testpassword');
+    await page.click('[type="submit"]');
+    await page.waitForURL('/dashboard');
+    await use(page);
+  }
+});
+```
+
+#### 6. Add Critical User Journey Tests
+Priority order:
+1. Complete signup → login flow
+2. AI chat interaction (core feature)
+3. Workspace creation and management
+4. Subscription upgrade flow
+
+#### 7. Implement Test Data Management
+- Database seeding script for e2e tests
+- Cleanup between test runs
+- Isolated test data per test
+
+### Long-term Improvements (1-2 months)
+
+#### 8. Expand Test Coverage to 80%+ of User Journeys
+- All authentication flows
+- All workspace operations
+- Complete payment flows
+- Admin operations
+- API key management
+
+#### 9. Add Visual Regression Testing
+- Screenshot comparison for UI consistency
+- Responsive design validation
+
+#### 10. Performance Testing
+- Page load benchmarks
+- API response time assertions
+
+#### 11. API Contract Testing
+- Verify API responses match OpenAPI spec
+- Error response validation
+
+### Testing Infrastructure
+
+#### 12. CI/CD Integration
+- Run e2e tests on pull requests
+- Parallel test execution
+- Test result reporting
+
+#### 13. Test Monitoring
+- Flaky test detection
+- Test duration tracking
+- Coverage reporting
+
+---
+
+## Recommended Test File Structure
+
+```
+e2e/
+├── fixtures/
+│   ├── auth.ts           # Authentication helpers
+│   ├── workspace.ts      # Workspace management helpers
+│   └── subscriptions.ts  # Billing helpers
+├── auth/
+│   ├── signup.spec.ts    # Complete signup flow
+│   ├── login.spec.ts     # Login variations
+│   ├── oauth.spec.ts     # Google OAuth
+│   └── password.spec.ts  # Password reset
+├── chat/
+│   ├── basic-chat.spec.ts
+│   ├── api-keys.spec.ts
+│   └── models.spec.ts
+├── workspaces/
+│   ├── create.spec.ts
+│   ├── members.spec.ts
+│   ├── settings.spec.ts
+│   └── permissions.spec.ts
+├── billing/
+│   ├── upgrade.spec.ts
+│   ├── checkout.spec.ts
+│   └── manage.spec.ts
+├── admin/
+│   ├── users.spec.ts
+│   └── audit-logs.spec.ts
+└── analytics/
+    └── dashboard.spec.ts
+```
+
+---
+
+## Coverage Comparison Table
+
+| Feature Area | Unit Tests | E2E Tests | Recommended E2E |
+|--------------|------------|-----------|-----------------|
+| Authentication | ✅ Good | ⚠️ Partial | ✅ Complete flows |
+| AI Chat | ✅ Good | ❌ None | ✅ Full interaction |
+| Workspaces | ✅ Good | ❌ None | ✅ CRUD + permissions |
+| Subscriptions | ✅ Good | ⚠️ Display only | ✅ Full payment flow |
+| Admin Panel | ✅ Good | ⚠️ Access only | ✅ All operations |
+| Analytics | ✅ Good | ❌ None | ✅ Data display |
+| API Keys | ✅ Good | ❌ None | ✅ Management UI |
+| Audit Logs | ✅ Good | ❌ None | ⚠️ View only |
+| Theme/UI | ⚠️ Limited | ✅ Excellent | ✅ Keep current |
+
+---
+
+## Estimated Test Implementation Effort
+
+| Priority | Test Area | Estimated Tests | Time Estimate |
+|----------|-----------|-----------------|---------------|
+| 🔴 Critical | Auth complete flows | 15-20 | 2-3 days |
+| 🔴 Critical | AI chat functionality | 10-15 | 2-3 days |
+| 🔴 Critical | Workspace management | 20-25 | 3-4 days |
+| 🔴 Critical | Payment flows | 10-12 | 2-3 days |
+| 🟡 Medium | Admin operations | 15-20 | 2-3 days |
+| 🟡 Medium | API key management | 8-10 | 1-2 days |
+| 🟡 Medium | Analytics dashboard | 5-8 | 1 day |
+| 🟡 Medium | Session management | 5-8 | 1 day |
+| 🟢 Low | Error scenarios | 15-20 | 2-3 days |
+| 🟢 Low | Performance tests | 10-15 | 2-3 days |
+
+**Total Estimated New Tests**: 113-153 tests
+**Total Implementation Time**: 18-27 days
+
+---
+
+## Application Routes Analysis
+
+### Existing Pages (22 total)
+
+**Public Routes:**
+- `/` - Landing page
+- `/login` - Login page
+- `/signup` - Signup page
+- `/forgot-password` - Password reset request
+- `/reset-password` - Password reset form
+
+**Protected Routes:**
+- `/dashboard` - Main dashboard
+- `/dashboard/subscriptions` - Subscription management
+- `/dashboard/analytics` - Usage analytics
+- `/dashboard/sessions` - AI chat sessions
+- `/dashboard/workspaces` - Workspace list
+- `/dashboard/workspaces/create` - Create workspace
+- `/aichat` - AI chat interface
+- `/billing` - Billing overview
+- `/billing/success` - Payment success page
+- `/api-docs` - API documentation
+- `/workspace/[slug]` - Workspace detail
+- `/workspace/[slug]/settings` - Workspace settings
+- `/workspace/[slug]/members` - Workspace members
+
+**Admin Routes:**
+- `/admin` - Admin dashboard
+- `/admin/users` - User management
+- `/admin/audit-logs` - Audit log viewer
+
+**Other:**
+- `/sentry-example-page` - Sentry testing page
+
+### API Routes (20 total)
+
+- `/api/auth/[...all]` - Better Auth endpoints
+- `/api/chat` - AI chat endpoint
+- `/api/sessions` - Session management
+- `/api/health` - Health check
+- `/api/models` - Available AI models
+- `/api/analytics` - Analytics data
+- `/api/user/api-keys` - User API key management
+- `/api/billing/usage` - Usage tracking
+- `/api/billing/checkout` - Checkout session
+- `/api/billing/subscription` - Subscription management
+- `/api/admin/users` - Admin user management
+- `/api/admin/audit-logs` - Audit log access
+- `/api/workspaces` - Workspace CRUD
+- `/api/workspaces/[id]` - Workspace operations
+- `/api/workspaces/[id]/members` - Member management
+- `/api/workspaces/[id]/members/[userId]` - Member operations
+- `/api/workspaces/[id]/invitations` - Invitations
+- `/api/workspaces/[id]/invitations/[invitationId]` - Invitation operations
+- `/api/webhooks/polar` - Payment webhooks
+- `/api/accept-invitation` - Accept workspace invitation
+- `/api/sentry-example-api` - Sentry testing
+
+---
+
+## Conclusion
+
+### Current State
+- **E2E tests are not running** due to missing environment configuration
+- **Test coverage is insufficient** for a production SaaS application
+- **Core features** (AI chat, workspaces, payments) have zero e2e coverage
+- **Unit test coverage is excellent**, but e2e tests don't validate user journeys
+
+### Is E2E Testing Comprehensive?
+**No.** The current e2e test suite covers approximately **20-25% of critical user journeys**. For a production SaaS application, you should aim for 80%+ coverage of primary user flows.
+
+### Priority Actions
+1. **Fix infrastructure** (environment setup) - 1 day
+2. **Add authentication fixtures** - 1 day
+3. **Implement core journey tests** (auth, chat, workspaces, billing) - 10-12 days
+4. **Expand coverage iteratively** based on feature priority
+
+### Success Metrics
+After implementing recommendations:
+- ✅ All tests should run successfully in CI/CD
+- ✅ Coverage of 80%+ critical user journeys
+- ✅ Complete happy paths for all major features
+- ✅ Error scenario coverage for edge cases
+- ✅ Tests complete in < 15 minutes
+
+---
+
+## Next Steps
+
+1. **Configure test environment** with `.env` file containing `DATABASE_URL`
+2. **Run tests locally** to verify infrastructure fixes
+3. **Review test results** and identify which tests actually pass
+4. **Prioritize test implementation** based on business-critical features
+5. **Create test fixtures** for authenticated user flows
+6. **Implement missing tests** incrementally, starting with critical paths
+
+---
+
+**Report Generated**: 2025-11-18
+**Author**: Claude AI Assistant
+**Purpose**: Diagnostic analysis of e2e test failures and coverage gaps


### PR DESCRIPTION
Add /test-results/ and /playwright-report/ directories to .gitignore to prevent Playwright test output files from being tracked. These directories are generated during e2e test runs and should not be committed to the repository.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated testing infrastructure configuration and diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->