### PR TITLE
feat: Next.js 16 tasks 7 & 10 — "use cache" directive + error boundary helpers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,6 +122,10 @@ See `.env.example` for all required variables. Key groups:
 - `SENTRY_*`, `NEXT_PUBLIC_SENTRY_DSN` — Error tracking
 - `NEXT_PUBLIC_POSTHOG_KEY/HOST` — Analytics (optional)
 
+## TODOs
+
+All Next.js 16.x upgrade tasks complete (merged via PR #72 and PR #73).
+
 ## Pre-Push Checklist
 
 Before every push:

--- a/next.config.ts
+++ b/next.config.ts
@@ -33,7 +33,10 @@ const nextConfig: NextConfig = {
   experimental: {
     optimizeCss: true,
     optimizePackageImports: ['lucide-react', '@radix-ui/react-icons'],
-    // cacheComponents disabled due to incompatibility with API routes and system pages
+    // useCache enables the "use cache" directive for async server functions
+    useCache: true,
+    // cacheComponents enables component-level caching (PPR model) — disabled due
+    // to known incompatibility with API routes and Next.js system pages
     // cacheComponents: true,
     turbopackFileSystemCacheForBuild: true,
     sri: { algorithm: 'sha256' as const },

--- a/src/app/admin/error.tsx
+++ b/src/app/admin/error.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+
+type ErrorInfo = {
+  error: Error & { digest?: string };
+  reset: () => void;
+  unstable_retry: () => void;
+};
+
+export default function AdminError({ error, unstable_retry }: ErrorInfo) {
+  const router = useRouter();
+
+  return (
+    <div className="flex flex-1 flex-col items-center justify-center gap-4 p-8 text-center">
+      <div className="flex flex-col items-center gap-2">
+        <h2 className="text-xl font-semibold tracking-tight">Admin error</h2>
+        <p className="text-muted-foreground max-w-sm text-sm">
+          {error.message || 'Failed to load admin panel. Please try again.'}
+        </p>
+        {error.digest && (
+          <p className="text-muted-foreground font-mono text-xs">
+            Error ID: {error.digest}
+          </p>
+        )}
+      </div>
+      <div className="flex gap-3">
+        <button
+          type="button"
+          onClick={unstable_retry}
+          className="bg-primary text-primary-foreground hover:bg-primary/90 rounded-md px-4 py-2 text-sm font-medium transition-colors"
+        >
+          Try again
+        </button>
+        <button
+          type="button"
+          onClick={() => router.push('/dashboard')}
+          className="border-input bg-background hover:bg-accent hover:text-accent-foreground rounded-md border px-4 py-2 text-sm font-medium transition-colors"
+        >
+          Back to dashboard
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/error.tsx
+++ b/src/app/admin/error.tsx
@@ -1,12 +1,7 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
-
-type ErrorInfo = {
-  error: Error & { digest?: string };
-  reset: () => void;
-  unstable_retry: () => void;
-};
+import type { ErrorInfo } from '@/types/error';
 
 export default function AdminError({ error, unstable_retry }: ErrorInfo) {
   const router = useRouter();

--- a/src/app/dashboard/error.tsx
+++ b/src/app/dashboard/error.tsx
@@ -1,12 +1,7 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
-
-type ErrorInfo = {
-  error: Error & { digest?: string };
-  reset: () => void;
-  unstable_retry: () => void;
-};
+import type { ErrorInfo } from '@/types/error';
 
 export default function DashboardError({ error, unstable_retry }: ErrorInfo) {
   const router = useRouter();

--- a/src/app/dashboard/error.tsx
+++ b/src/app/dashboard/error.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+
+type ErrorInfo = {
+  error: Error & { digest?: string };
+  reset: () => void;
+  unstable_retry: () => void;
+};
+
+export default function DashboardError({ error, unstable_retry }: ErrorInfo) {
+  const router = useRouter();
+
+  return (
+    <div className="flex flex-1 flex-col items-center justify-center gap-4 p-8 text-center">
+      <div className="flex flex-col items-center gap-2">
+        <h2 className="text-xl font-semibold tracking-tight">
+          Dashboard error
+        </h2>
+        <p className="text-muted-foreground max-w-sm text-sm">
+          {error.message || 'Failed to load dashboard. Please try again.'}
+        </p>
+        {error.digest && (
+          <p className="text-muted-foreground font-mono text-xs">
+            Error ID: {error.digest}
+          </p>
+        )}
+      </div>
+      <div className="flex gap-3">
+        <button
+          type="button"
+          onClick={unstable_retry}
+          className="bg-primary text-primary-foreground hover:bg-primary/90 rounded-md px-4 py-2 text-sm font-medium transition-colors"
+        >
+          Try again
+        </button>
+        <button
+          type="button"
+          onClick={() => router.push('/')}
+          className="border-input bg-background hover:bg-accent hover:text-accent-foreground rounded-md border px-4 py-2 text-sm font-medium transition-colors"
+        >
+          Go home
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+// ErrorInfo from Next.js 16.2 — error.digest is added at runtime but not in the
+// public type; intersect to make it accessible without unsafe casting.
+type ErrorInfo = {
+  error: Error & { digest?: string };
+  reset: () => void;
+  unstable_retry: () => void;
+};
+
+/**
+ * Root error boundary for the application.
+ *
+ * Uses Next.js 16.2's unstable_retry from ErrorInfo for proper RSC re-fetch:
+ * it calls router.refresh() + reset() inside a transition so the server
+ * re-renders the failed subtree rather than just resetting client state.
+ */
+export default function AppError({ error, reset, unstable_retry }: ErrorInfo) {
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center gap-4 p-8 text-center">
+      <div className="flex flex-col items-center gap-2">
+        <h2 className="text-2xl font-semibold tracking-tight">
+          Something went wrong
+        </h2>
+        <p className="text-muted-foreground max-w-md text-sm">
+          {error.message || 'An unexpected error occurred. Please try again.'}
+        </p>
+        {error.digest && (
+          <p className="text-muted-foreground font-mono text-xs">
+            Error ID: {error.digest}
+          </p>
+        )}
+      </div>
+      <div className="flex gap-3">
+        <button
+          type="button"
+          onClick={unstable_retry}
+          className="bg-primary text-primary-foreground hover:bg-primary/90 rounded-md px-4 py-2 text-sm font-medium transition-colors"
+        >
+          Try again
+        </button>
+        <button
+          type="button"
+          onClick={reset}
+          className="border-input bg-background hover:bg-accent hover:text-accent-foreground rounded-md border px-4 py-2 text-sm font-medium transition-colors"
+        >
+          Reset
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,12 +1,6 @@
 'use client';
 
-// ErrorInfo from Next.js 16.2 — error.digest is added at runtime but not in the
-// public type; intersect to make it accessible without unsafe casting.
-type ErrorInfo = {
-  error: Error & { digest?: string };
-  reset: () => void;
-  unstable_retry: () => void;
-};
+import type { ErrorInfo } from '@/types/error';
 
 /**
  * Root error boundary for the application.

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -1,27 +1,39 @@
 'use client';
 
+type ErrorInfo = {
+  error: Error & { digest?: string };
+  reset: () => void;
+  unstable_retry: () => void;
+};
+
 // Prevent static generation of this error page
 export const dynamic = 'force-dynamic';
 export const dynamicParams = true;
 
-// Note: global-error.tsx must be a client component per Next.js requirements
-// However, we keep it minimal to avoid prerender issues
-export default function GlobalError({
-  error: _error,
-  reset,
-}: {
-  error: Error & { digest?: string };
-  reset: () => void;
-}) {
+// Note: global-error.tsx must be a client component per Next.js requirements.
+// It replaces the root layout on catastrophic errors, so it must render <html>.
+// Uses unstable_retry for proper RSC re-fetch (router.refresh + reset in a transition).
+export default function GlobalError({ error, unstable_retry }: ErrorInfo) {
   return (
     <html lang="en">
       <body>
         <div style={{ padding: '2rem', textAlign: 'center' }}>
           <h1>Something went wrong!</h1>
           <p>An unexpected error occurred. Please try refreshing the page.</p>
+          {error.digest && (
+            <p
+              style={{
+                fontSize: '0.75rem',
+                color: '#666',
+                fontFamily: 'monospace',
+              }}
+            >
+              Error ID: {error.digest}
+            </p>
+          )}
           <button
             type="button"
-            onClick={reset}
+            onClick={unstable_retry}
             style={{
               marginTop: '1rem',
               padding: '0.5rem 1rem',

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -1,10 +1,6 @@
 'use client';
 
-type ErrorInfo = {
-  error: Error & { digest?: string };
-  reset: () => void;
-  unstable_retry: () => void;
-};
+import type { ErrorInfo } from '@/types/error';
 
 // Prevent static generation of this error page
 export const dynamic = 'force-dynamic';

--- a/src/lib/subscription-features.ts
+++ b/src/lib/subscription-features.ts
@@ -1,6 +1,6 @@
 import 'server-only';
 import { eq } from 'drizzle-orm';
-import { unstable_cache } from 'next/cache';
+import { cacheLife, cacheTag } from 'next/cache';
 import { db } from '@/db/drizzle';
 import { subscription as subscriptionTable } from '@/db/schema';
 
@@ -44,43 +44,38 @@ export type PlanName = keyof typeof PLAN_FEATURES;
 export type PlanFeatures = (typeof PLAN_FEATURES)[PlanName];
 
 /**
- * Get user's current subscription plan
- * Returns 'free' if no active subscription found
- * Cached with unstable_cache for cross-request persistence (1 hour TTL)
- * Tagged with user-plan:${userId} for per-user invalidation and 'user-plan' for bulk invalidation
+ * Get user's current subscription plan.
+ * Returns 'free' if no active subscription found.
+ * Cached with the "use cache" directive for cross-request persistence (1 hour TTL).
+ * Tagged with user-plan:${userId} for per-user invalidation and 'user-plan' for bulk invalidation.
  */
-export const getUserPlan = async (userId: string): Promise<PlanName> => {
-  return unstable_cache(
-    async () => {
-      try {
-        const subscription = await db.query.subscription.findFirst({
-          where: eq(subscriptionTable.userId, userId),
-        });
+export async function getUserPlan(userId: string): Promise<PlanName> {
+  'use cache';
+  cacheTag(`user-plan:${userId}`, 'user-plan');
+  cacheLife('hours');
 
-        // If no subscription or inactive, default to free
-        if (!subscription || subscription.status !== 'active') {
-          return 'free';
-        }
+  try {
+    const subscription = await db.query.subscription.findFirst({
+      where: eq(subscriptionTable.userId, userId),
+    });
 
-        // Validate plan name
-        const planName = subscription.plan.toLowerCase();
-        if (planName in PLAN_FEATURES) {
-          return planName as PlanName;
-        }
+    // If no subscription or inactive, default to free
+    if (!subscription || subscription.status !== 'active') {
+      return 'free';
+    }
 
-        return 'free';
-      } catch (error) {
-        console.error('Error fetching user plan:', error);
-        return 'free';
-      }
-    },
-    [`user-plan-${userId}`],
-    {
-      tags: [`user-plan:${userId}`, 'user-plan'],
-      revalidate: 3600,
-    },
-  )();
-};
+    // Validate plan name
+    const planName = subscription.plan.toLowerCase();
+    if (planName in PLAN_FEATURES) {
+      return planName as PlanName;
+    }
+
+    return 'free';
+  } catch (error) {
+    console.error('Error fetching user plan:', error);
+    return 'free';
+  }
+}
 
 /**
  * Get plan features for a user

--- a/src/lib/workspace-billing.ts
+++ b/src/lib/workspace-billing.ts
@@ -9,7 +9,7 @@
 
 import 'server-only';
 import { and, eq, sql } from 'drizzle-orm';
-import { unstable_cache } from 'next/cache';
+import { cacheLife, cacheTag } from 'next/cache';
 import { db } from '@/db/drizzle';
 import {
   subscription as subscriptionTable,
@@ -31,23 +31,18 @@ import {
  * @param workspaceId - Workspace ID
  * @returns Workspace subscription or null
  */
-export const getWorkspaceSubscription = async (workspaceId: string) => {
-  return unstable_cache(
-    async () => {
-      return db.query.subscription.findFirst({
-        where: and(
-          eq(subscriptionTable.workspaceId, workspaceId),
-          eq(subscriptionTable.status, 'active'),
-        ),
-      });
-    },
-    [`workspace-sub-${workspaceId}`],
-    {
-      tags: [`workspace-sub:${workspaceId}`, 'workspace-sub'],
-      revalidate: 3600,
-    },
-  )();
-};
+export async function getWorkspaceSubscription(workspaceId: string) {
+  'use cache';
+  cacheTag(`workspace-sub:${workspaceId}`, 'workspace-sub');
+  cacheLife('hours');
+
+  return db.query.subscription.findFirst({
+    where: and(
+      eq(subscriptionTable.workspaceId, workspaceId),
+      eq(subscriptionTable.status, 'active'),
+    ),
+  });
+}
 
 /**
  * Get workspace plan.

--- a/src/types/error.ts
+++ b/src/types/error.ts
@@ -1,0 +1,11 @@
+/**
+ * Next.js 16.2 error boundary props.
+ * error.digest is added at runtime but not in the public type;
+ * we intersect to make it accessible without unsafe casting.
+ * unstable_retry performs proper RSC re-fetch (router.refresh + reset in a transition).
+ */
+export type ErrorInfo = {
+  error: Error & { digest?: string };
+  reset: () => void;
+  unstable_retry: () => void;
+};

--- a/unit-tests/setup.ts
+++ b/unit-tests/setup.ts
@@ -6,11 +6,14 @@ import { afterEach, beforeEach, vi } from 'vitest';
 // Mock server-only module to prevent import errors in tests
 vi.mock('server-only', () => ({}));
 
-// Mock next/cache — unstable_cache requires Next.js's incremental cache which
-// doesn't exist in Vitest. Make it a transparent pass-through so cached
-// functions behave identically to their uncached equivalents in tests.
+// Mock next/cache — both unstable_cache and the "use cache" directive helpers
+// (cacheTag, cacheLife) require Next.js's incremental cache which doesn't exist
+// in Vitest. Make them no-ops so cached functions behave like their uncached
+// equivalents in tests.
 vi.mock('next/cache', () => ({
   unstable_cache: <T extends (...args: unknown[]) => unknown>(fn: T) => fn,
+  cacheTag: vi.fn(),
+  cacheLife: vi.fn(),
   revalidateTag: vi.fn(),
   revalidatePath: vi.fn(),
 }));


### PR DESCRIPTION
## Summary

Completes the remaining deferred Next.js 16 upgrade tasks from CLAUDE.md (Tasks 7 and 10). Tasks 8 (proxy.ts) and 9 (React Compiler) were already implemented in prior commits.

### Task 7 — \`"use cache"\` directive
- Replaces `unstable_cache` in `src/lib/subscription-features.ts` (`getUserPlan`) and `src/lib/workspace-billing.ts` (`getWorkspaceSubscription`) with the stable `"use cache"` directive + `cacheTag()`/`cacheLife()` APIs from `next/cache`
- Cache keys are now auto-derived from function arguments — no manual key arrays
- Enables `useCache: true` in `next.config.ts` experimental (the Next.js 16 flag for the `"use cache"` directive; `dynamicIO` was the old name)
- `cacheLife('hours')` replaces `revalidate: 3600`; `cacheTag(...)` replaces the `tags` option
- Updates `unit-tests/setup.ts` to mock `cacheTag`/`cacheLife` as no-ops alongside the existing `unstable_cache` mock

### Task 10 — Error boundary helpers
- Adds `src/app/error.tsx` (root error boundary) using `unstable_retry` from `ErrorInfo` — calls `router.refresh() + reset()` in a transition so the server re-renders the failed RSC subtree rather than just resetting client state
- Adds `src/app/dashboard/error.tsx` and `src/app/admin/error.tsx` as scoped boundaries with contextual back-navigation
- Updates `src/app/global-error.tsx` to use `unstable_retry` instead of bare `reset()`
- All error components accept the `ErrorInfo` shape (error + reset + unstable_retry) with `error.digest` typed as `Error & { digest?: string }` to match what Next.js passes at runtime

## Notes

- `cacheComponents: true` remains disabled — it gates PPR component-level caching which has known incompatibility with API routes; the `"use cache"` directive on async functions works independently via `useCache: true`
- `unstable_catchError` is a component-level HOC wrapping pattern (`unstable_catchError(FallbackComponent)`) — separate from error.tsx; not added here as it targets inline component error handling, not the route-level error boundary convention

## Test plan

- [x] `bun run lint` — zero errors
- [x] `bun run type-check` — no TypeScript errors
- [x] Unit tests for `subscription-features` and `usage-tracker` pass (69 tests)
- [ ] Production build with `next build`
- [ ] Verify subscription cache invalidation still works end-to-end after webhook fires

Karthikeyan N <karthiknitt@gmail.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dedicated error screens across the app (app, dashboard, admin, global) showing messages, optional Error IDs, and recovery actions ("Try again", "Reset", navigation).

* **Chores**
  * Enabled experimental Next.js server-function caching (useCache: true).
  * Introduced a shared ErrorInfo type for error boundary props.
  * Updated test setup to mock new cache helpers so tests run without native incremental cache.

* **Documentation**
  * Added TODOs note about Next.js upgrade tasks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->